### PR TITLE
Enhance photo metadata handling across components

### DIFF
--- a/frontend/src/lib/photoDisplay.head.test.ts
+++ b/frontend/src/lib/photoDisplay.head.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+	displayTitle,
+	buildHeadTitle,
+	buildHeadDescription,
+	firstAnnotationText,
+	annotationKeywords,
+	dedupeCaseInsensitive,
+	type PublicPhoto,
+	type PhotoAnnotation
+} from './photoDisplay';
+
+// Minimal factories — only the fields the head/title helpers read.
+const photo = (p: Partial<PublicPhoto>): PublicPhoto =>
+	({
+		title: null,
+		description: null,
+		original_filename: null,
+		place_name: null,
+		latitude: null,
+		longitude: null,
+		...p
+	}) as unknown as PublicPhoto;
+
+const ann = (body: string | null): PhotoAnnotation =>
+	({ id: 'a', body, owner_username: 'kolman.jindrich', created_at: '2026-06-03T00:00:00Z' }) as PhotoAnnotation;
+
+describe('displayTitle', () => {
+	it('prefers an explicit title over everything', () => {
+		expect(displayTitle(photo({ title: 'Havránka', description: 'd', original_filename: 'f.jpg' }), [ann('X')]))
+			.toBe('Havránka');
+	});
+
+	it('uses the description when there is no title', () => {
+		expect(displayTitle(photo({ description: 'Panorama Prahy z Havránky.' }))).toBe('Panorama Prahy z Havránky.');
+	});
+
+	it('prefers a landmark annotation over a raw camera filename', () => {
+		expect(displayTitle(photo({ original_filename: '036A8750.webp' }), [ann('Prosek Point')]))
+			.toBe('Prosek Point');
+	});
+
+	it('beats an emoji/garbage filename with the annotation', () => {
+		expect(
+			displayTitle(photo({ original_filename: '2025-08-10-20-31-37_↻🔸⟸🌤️.jpg' }), [
+				ann('Partyzánská, elektrárna Holešovice')
+			])
+		).toBe('Partyzánská, elektrárna Holešovice');
+	});
+
+	it('skips placeholder annotations, then falls to the filename', () => {
+		expect(displayTitle(photo({ original_filename: 'x.jpg' }), [ann('?'), ann('oops')])).toBe('x.jpg');
+	});
+
+	it('falls back to the first meaningful annotation past the placeholders', () => {
+		expect(displayTitle(photo({ original_filename: 'x.jpg' }), [ann('?'), ann('Žižka')])).toBe('Žižka');
+	});
+
+	it('is backward-compatible for grid callers that pass no annotations', () => {
+		expect(displayTitle(photo({ original_filename: 'x.jpg' }))).toBe('x.jpg');
+		expect(displayTitle(photo({}))).toBe('Photo');
+	});
+});
+
+describe('buildHeadTitle', () => {
+	it('promotes an annotation into the head title and suffixes the site name', () => {
+		expect(buildHeadTitle(photo({ original_filename: 'x.jpg' }), [ann('Prosek Point')]))
+			.toBe('Prosek Point - Hillview');
+	});
+});
+
+describe('buildHeadDescription', () => {
+	it('uses the description alone — no annotation splice, no coordinate tail', () => {
+		expect(
+			buildHeadDescription(
+				photo({
+					description: 'Panorama Prahy z Havránky.',
+					place_name: 'Praha-Troja, Praha',
+					latitude: 50.1197,
+					longitude: 14.4219
+				})
+			)
+		).toBe('Panorama Prahy z Havránky.');
+	});
+
+	it('falls back to the place name before coordinates', () => {
+		expect(buildHeadDescription(photo({ place_name: 'Říčany', latitude: 49.9844, longitude: 14.6662 })))
+			.toBe('Říčany');
+	});
+
+	it('uses coordinates only as a last resort', () => {
+		expect(buildHeadDescription(photo({ latitude: 50.1607, longitude: 14.5274 }))).toBe('50.1607, 14.5274');
+	});
+
+	it('has a generic fallback when nothing is known', () => {
+		expect(buildHeadDescription(photo({}))).toBe('Photo on Hillview');
+	});
+});
+
+describe('firstAnnotationText', () => {
+	it('returns the first text segment, skipping a leading URL segment', () => {
+		expect(firstAnnotationText([ann('https://cs.wikipedia.org/wiki/X|Husův sbor')])).toBe('Husův sbor');
+	});
+	it('returns empty string when there is nothing meaningful', () => {
+		expect(firstAnnotationText([ann(null), ann('?'), ann('')])).toBe('');
+	});
+});
+
+describe('annotationKeywords', () => {
+	it('collects distinct labels, dropping placeholders and de-duplicating case-insensitively', () => {
+		const labels = annotationKeywords([
+			ann('Průmyslový palác'),
+			ann('průmyslový palác'),
+			ann('PRŮMYSLOVÝ PALÁC'),
+			ann('?'),
+			ann('oops'),
+			ann('Žižka')
+		]);
+		expect(labels).toEqual(['Průmyslový palác', 'Žižka']);
+	});
+
+	it('keeps text segments of a piped body but drops the URL segment', () => {
+		expect(annotationKeywords([ann('Praha Bubny|https://cs.wikipedia.org/wiki/Praha-Bubny')]))
+			.toEqual(['Praha Bubny']);
+		expect(annotationKeywords([ann('vysehrad|Grand Hotel Prague Towers')]))
+			.toEqual(['vysehrad', 'Grand Hotel Prague Towers']);
+	});
+
+	it('ignores empty/null bodies', () => {
+		expect(annotationKeywords([ann(null), ann('')])).toEqual([]);
+		expect(annotationKeywords()).toEqual([]);
+	});
+});
+
+describe('dedupeCaseInsensitive', () => {
+	it('keeps first casing and order, drops empties and case-dupes', () => {
+		expect(dedupeCaseInsensitive(['Praha', 'praha', 'B', '', '  ', 'b'])).toEqual(['Praha', 'B']);
+	});
+});

--- a/frontend/src/lib/photoDisplay.jsonld.test.ts
+++ b/frontend/src/lib/photoDisplay.jsonld.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildPhotoImageJsonLd, pickOgImage, type PublicPhoto } from './photoDisplay';
+import { buildPhotoImageJsonLd, pickOgImage, type PublicPhoto, type PhotoAnnotation } from './photoDisplay';
 import { serializeJsonLd } from './jsonld';
+
+const ann = (body: string): PhotoAnnotation =>
+	({ id: 'a', body, owner_username: 'kolman.jindrich', created_at: '2026-06-03T00:00:00Z' }) as PhotoAnnotation;
 
 // A real /api/photos/public/<uid> payload (captured from a prod-data copy):
 // an all-rights-reserved panorama, no description, owned by 'test'.
@@ -159,6 +162,26 @@ describe('buildPhotoImageJsonLd', () => {
 		expect(withKw.keywords).toEqual(['Gröbovka', 'Havlíčkovy sady']);
 		expect(buildPhotoImageJsonLd({ ...REAL_PHOTO, keywords: [] })!.keywords).toBeUndefined();
 		expect(buildPhotoImageJsonLd(REAL_PHOTO)!.keywords).toBeUndefined();
+	});
+
+	it('folds annotated landmark labels into keywords (deduped, placeholders/URLs dropped)', () => {
+		const ld = buildPhotoImageJsonLd(REAL_PHOTO, [
+			ann('Petřín'),
+			ann('petřín'),
+			ann('?'),
+			ann('Praha Bubny|https://cs.wikipedia.org/wiki/Praha-Bubny')
+		])!;
+		expect(ld.keywords).toEqual(['Petřín', 'Praha Bubny']);
+	});
+
+	it('merges curator keywords with annotation labels, deduped across both', () => {
+		const ld = buildPhotoImageJsonLd({ ...REAL_PHOTO, keywords: ['Praha'] }, [ann('praha'), ann('Petřín')])!;
+		expect(ld.keywords).toEqual(['Praha', 'Petřín']);
+	});
+
+	it('name falls back to the first annotation before the filename', () => {
+		const ld = buildPhotoImageJsonLd(REAL_PHOTO, [ann('Prosek Point')])!;
+		expect(ld.name).toBe('Prosek Point');
 	});
 });
 

--- a/frontend/src/lib/photoDisplay.ts
+++ b/frontend/src/lib/photoDisplay.ts
@@ -154,7 +154,8 @@ export function buildCopyrightNotice(photo: {
  * against real API payloads.
  */
 export function buildPhotoImageJsonLd(
-	photo: PublicPhoto | null
+	photo: PublicPhoto | null,
+	annotations: PhotoAnnotation[] = []
 ): Record<string, unknown> | null {
 	if (!photo) return null;
 	// contentUrl: highest-res variant we'd hand a crawler (capped below 'full',
@@ -184,12 +185,20 @@ export function buildPhotoImageJsonLd(
 						: undefined
 				}
 			: undefined;
+	// keywords: any curator-set keywords, plus the distinct landmark labels the
+	// annotations name — deduped case-insensitively across both. These describe
+	// what's actually in the frame (a topical/geographic signal for the image),
+	// so a densely-annotated Prague pano reads unambiguously as a view *of Prague*.
+	const keywords = dedupeCaseInsensitive([
+		...(photo.keywords ?? []),
+		...annotationKeywords(annotations)
+	]);
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'ImageObject',
-		name: displayTitle(photo),
+		name: displayTitle(photo, annotations),
 		description: photo.description || undefined,
-		keywords: photo.keywords && photo.keywords.length ? photo.keywords : undefined,
+		keywords: keywords.length ? keywords : undefined,
 		contentUrl: content?.url || undefined,
 		thumbnailUrl: thumb?.url || undefined,
 		width: content?.width || undefined,
@@ -213,12 +222,26 @@ export function buildPhotoImageJsonLd(
 	};
 }
 
-export function displayTitle(photo: {
-	title?: string | null;
-	description?: string | null;
-	original_filename: string | null;
-}): string {
-	return photo.title || photo.description || photo.original_filename || 'Photo';
+export function displayTitle(
+	photo: {
+		title?: string | null;
+		description?: string | null;
+		original_filename: string | null;
+	},
+	annotations: PhotoAnnotation[] = []
+): string {
+	// A user-written landmark label beats the raw camera filename (036A8750.webp,
+	// EOS dumps, emoji blobs) as the public title/h1/og:title. Annotations are the
+	// image's real caption when title + description are both empty, so prefer them
+	// before falling through to the filename. Grid callers pass no annotations and
+	// keep the old title/description/filename behaviour.
+	return (
+		photo.title ||
+		photo.description ||
+		firstAnnotationText(annotations) ||
+		photo.original_filename ||
+		'Photo'
+	);
 }
 
 export function parseAnnotationBody(body: string | null | undefined): AnnotationBodySegment[] {
@@ -232,51 +255,88 @@ export function parseAnnotationBody(body: string | null | undefined): Annotation
 		);
 }
 
+// A meaningful annotation segment is a text segment (not a URL) that isn't a
+// placeholder ('?', 'oops') the annotators use for "don't know yet".
+function meaningfulAnnotationText(value: string): string | null {
+	const trimmed = value.trim();
+	const placeholder = trimmed.toLowerCase();
+	if (!trimmed || placeholder === '?' || placeholder === 'oops') return null;
+	return trimmed;
+}
+
 /**
  * First meaningful text segment across a photo's annotations, or '' if none.
- * Skips link segments and placeholder bodies ('?', 'oops'). Used to enrich the
- * social/meta description with a human-written caption when one exists.
+ * Skips link segments and placeholder bodies. Used as a title fallback for
+ * photos whose only human text is a landmark label (see displayTitle).
  */
 export function firstAnnotationText(annotations: PhotoAnnotation[]): string {
 	for (const a of annotations) {
 		if (!a.body) continue;
 		for (const seg of parseAnnotationBody(a.body)) {
 			if (seg.kind !== 'text') continue;
-			const trimmed = seg.value.trim();
-			// Skip placeholder captions that carry no real information.
-			const placeholder = trimmed.toLowerCase();
-			if (!trimmed || placeholder === '?' || placeholder === 'oops') continue;
-			return trimmed;
+			const text = meaningfulAnnotationText(seg.value);
+			if (text) return text;
 		}
 	}
 	return '';
 }
 
+/**
+ * Distinct landmark labels a photo's annotations name, for schema.org keywords:
+ * text segments only (URLs dropped), placeholders skipped, de-duplicated
+ * case-insensitively (the raw set has repeats, e.g. 'Průmyslový palác' ×3).
+ */
+export function annotationKeywords(annotations: PhotoAnnotation[] = []): string[] {
+	const out: string[] = [];
+	for (const a of annotations) {
+		if (!a.body) continue;
+		for (const seg of parseAnnotationBody(a.body)) {
+			if (seg.kind !== 'text') continue;
+			const text = meaningfulAnnotationText(seg.value);
+			if (text) out.push(text);
+		}
+	}
+	return dedupeCaseInsensitive(out);
+}
+
+/** De-duplicate strings case-insensitively (by trimmed lowercase), keeping the
+ *  first occurrence's original casing and order. Drops empties. */
+export function dedupeCaseInsensitive(values: string[]): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const v of values) {
+		const key = v.trim().toLowerCase();
+		if (!key || seen.has(key)) continue;
+		seen.add(key);
+		out.push(v);
+	}
+	return out;
+}
+
 /** `<title>` / og:title for a photo: its display title suffixed with the site name. */
-export function buildHeadTitle(photo: PublicPhoto): string {
-	return `${displayTitle(photo)} - Hillview`;
+export function buildHeadTitle(photo: PublicPhoto, annotations: PhotoAnnotation[] = []): string {
+	return `${displayTitle(photo, annotations)} - Hillview`;
 }
 
 /**
- * og:description / <meta name="description"> for a photo: its description, the
- * first annotation caption, and coordinates joined together, with a generic
- * fallback. Deliberately loose human text — precise structured metadata lives in
- * the schema.org ImageObject (buildPhotoImageJsonLd) instead. Shared by the
- * /photo/[uid] detail route and the map homepage's ?photo= share cards so both
- * emit identical head tags.
+ * og:description / <meta name="description"> for a photo. Picks the best single
+ * human-readable line available: the author's description, else the
+ * reverse-geocoded place name, else the bare coordinates as a last resort.
+ *
+ * Deliberately does NOT splice in an annotation — cherry-picking the *first*
+ * label ("… — Strojimport") was arbitrary noise; the full landmark set now lives
+ * in the ImageObject's keywords, and a lone label (when it's all a photo has)
+ * surfaces as the title instead (see displayTitle). Precise structured metadata
+ * lives in buildPhotoImageJsonLd. Shared by the /photo/[uid] detail route and
+ * the map homepage's ?photo= share cards so both emit identical head tags.
  */
-export function buildHeadDescription(
-	photo: PublicPhoto,
-	annotations: PhotoAnnotation[] = []
-): string {
-	const parts: string[] = [];
-	if (photo.description) parts.push(photo.description);
-	const ann = firstAnnotationText(annotations);
-	if (ann) parts.push(ann);
+export function buildHeadDescription(photo: PublicPhoto): string {
+	if (photo.description) return photo.description;
+	if (photo.place_name) return photo.place_name;
 	if (photo.latitude != null && photo.longitude != null) {
-		parts.push(`${photo.latitude.toFixed(4)}, ${photo.longitude.toFixed(4)}`);
+		return `${photo.latitude.toFixed(4)}, ${photo.longitude.toFixed(4)}`;
 	}
-	return parts.join(' — ') || 'Photo on Hillview';
+	return 'Photo on Hillview';
 }
 
 export function formatDate(value: string | null | undefined): string {

--- a/frontend/src/routes/+page.svelte.web
+++ b/frontend/src/routes/+page.svelte.web
@@ -63,8 +63,8 @@
 
 {#if photo}
 	<PhotoHead
-		title={buildHeadTitle(photo)}
-		description={buildHeadDescription(photo, annotations)}
+		title={buildHeadTitle(photo, annotations)}
+		description={buildHeadDescription(photo)}
 		ogType="article"
 		ogUrl={$page.url.href}
 		ogImage={ogImage ? { url: ogImage.url, width: ogImage.width, height: ogImage.height } : null}
@@ -72,7 +72,7 @@
 		longitude={photo.longitude}
 		canonicalUrl={`${HILLVIEW_BASE_URL}/photo/${encodeURIComponent(photo.uid)}`}
 	/>
-	<JsonLd data={buildPhotoImageJsonLd(photo)} />
+	<JsonLd data={buildPhotoImageJsonLd(photo, annotations)} />
 {:else}
 	<PhotoHead
 		title="Hillview - annotated panoramas"

--- a/frontend/src/routes/photo/[uid]/+page.svelte
+++ b/frontend/src/routes/photo/[uid]/+page.svelte
@@ -272,13 +272,13 @@
 		myGoto(constructPhotoMapUrl(photo));
 	}
 
-	$: headTitle = photo ? buildHeadTitle(photo) : '';
+	$: headTitle = photo ? buildHeadTitle(photo, annotations) : '';
 	$: headOgImage = photo ? pickOgImage(photo) : null;
-	$: headDescription = photo ? buildHeadDescription(photo, annotations) : '';
-	// schema.org ImageObject for the photo (precise structured data, unlike the
-	// coord/annotation-stuffed headDescription). Built in photoDisplay so it's
+	$: headDescription = photo ? buildHeadDescription(photo) : '';
+	// schema.org ImageObject for the photo (precise structured data, incl. the
+	// annotated landmark labels as keywords). Built in photoDisplay so it's
 	// unit-testable against real payloads.
-	$: headJsonLd = buildPhotoImageJsonLd(photo);
+	$: headJsonLd = buildPhotoImageJsonLd(photo, annotations);
 </script>
 
 <svelte:window on:keydown={handleRatingKeydown} />
@@ -297,7 +297,7 @@
 {/if}
 
 <StandardHeaderWithAlert
-	title={photo ? displayTitle(photo) : 'Photo'}
+	title={photo ? displayTitle(photo, annotations) : 'Photo'}
 	showMenuButton={true}
 	fallbackHref="/"
 />
@@ -327,7 +327,7 @@
 			<div class="photo-container">
 				<img
 					src={getDisplayImageUrl(photo)}
-					alt={displayTitle(photo)}
+					alt={displayTitle(photo, annotations)}
 					data-testid="photo-detail-image"
 				/>
 			</div>


### PR DESCRIPTION
This update refactors how photo metadata, particularly titles and descriptions, are handled across various components in the frontend of the Hillview project. The changes introduce improved logic for annotating photos with metadata for both human readability and SEO purposes. The inclusion of annotations in functions like `buildHeadTitle` and `buildPhotoImageJsonLd` ensures richer, context-aware metadata. This includes deduplicating keywords case-insensitively and prioritizing human-readable annotations over raw filenames or geocoordinates, providing more meaningful and searchable content.

Key changes include:
- Support for dynamically including photo annotations in metadata computations.
- Simplification and consistent behavior in generating photo titles, utilizing annotations when available.
- Improved keyword extraction and deduplication for SEO benefits.
- Adjustments to unit tests to align with new logic and ensure integrity throughout the codebase.